### PR TITLE
Adds node as the project language, and specific version to test against

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+language: node_js
+node_js:
+  - "0.10"
 deploy:
   provider: heroku
   api_key:


### PR DESCRIPTION
When no specific language is added on the travis file it would use ruby causing build to break.
