### PR TITLE
fix app.js run block checking for logged in user.

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -57,7 +57,9 @@ var app = angular.module("Lucere", ["ngResource", "ngRoute", "dndLists"])
     $rootScope.$on("$routeChangeStart", function(e) {
       if(!AuthService.loggedIn()) {
         AuthService.login(function(user) {
-          if(user.teams.length === 0 && user.administrating.length === 0) {
+          if(!user) {
+            $location.path("/login");
+          } else if(user.teams.length === 0 && user.administrating.length === 0) {
             $location.path("/user/"+user.id);
           }
         });    


### PR DESCRIPTION
App.js file was modified, and the if statement which redirected to the login page if there was no user was removed. This adds that statement back in, and leaves the new statement checking to see if a user should be able to access any teams or libraries.

Note that this means that a user on no teams cannot access any team, but that a user on one team can access all teams. If we want users to only be able to view team pages that they are part of, one way would be to mimic the way we're checking for libraries. I personally don't know that teams should be private, necessarily. This also raises a question about users: should user profiles be available to any users? Probably not, in my opinion, since we're requiring name, email, github, and twitter.
